### PR TITLE
switch mounted condition up to superclass

### DIFF
--- a/example/lib/use_widget_ref_synchronously_lint_rule.dart
+++ b/example/lib/use_widget_ref_synchronously_lint_rule.dart
@@ -15,19 +15,19 @@ class UseWidgetRefSynchronouslyLintRule extends HookConsumerWidget {
     // expect_lint: use_widget_ref_synchronously
     await ref
         .read(asyncStateCounterNotifierProvider.notifier)
-        .incrementCounter();
+        .asyncIncrementCounter();
 
     if (context.mounted) {
-      await ref
+      ref
           .read(asyncStateCounterNotifierProvider.notifier)
-          .incrementCounter();
+          .syncIncrementCounter();
     }
 
     if (!context.mounted) {
       // expect_lint: use_widget_ref_synchronously
-      await ref
+      ref
           .read(asyncStateCounterNotifierProvider.notifier)
-          .incrementCounter();
+          .syncIncrementCounter();
       return;
     }
 
@@ -35,9 +35,7 @@ class UseWidgetRefSynchronouslyLintRule extends HookConsumerWidget {
       return;
     }
 
-    await ref
-        .read(asyncStateCounterNotifierProvider.notifier)
-        .incrementCounter();
+    ref.read(asyncStateCounterNotifierProvider.notifier).syncIncrementCounter();
   }
 
   @override
@@ -68,19 +66,19 @@ class UseWidgetRefSynchronouslyLintRule extends HookConsumerWidget {
             // expect_lint: use_widget_ref_synchronously
             await ref
                 .read(asyncStateCounterNotifierProvider.notifier)
-                .incrementCounter();
+                .asyncIncrementCounter();
 
             if (context.mounted) {
-              await ref
+              ref
                   .read(asyncStateCounterNotifierProvider.notifier)
-                  .incrementCounter();
+                  .syncIncrementCounter();
             }
 
             if (!context.mounted) {
               // expect_lint: use_widget_ref_synchronously
-              await ref
+              ref
                   .read(asyncStateCounterNotifierProvider.notifier)
-                  .incrementCounter();
+                  .syncIncrementCounter();
               return;
             }
 
@@ -88,9 +86,9 @@ class UseWidgetRefSynchronouslyLintRule extends HookConsumerWidget {
               return;
             }
 
-            await ref
+            ref
                 .read(asyncStateCounterNotifierProvider.notifier)
-                .incrementCounter();
+                .syncIncrementCounter();
           },
         ),
       ],
@@ -117,19 +115,19 @@ class _StatefulUseWidgetRefSynchronouslyLintRuleState
     // expect_lint: use_widget_ref_synchronously
     await ref
         .read(asyncStateCounterNotifierProvider.notifier)
-        .incrementCounter();
+        .asyncIncrementCounter();
 
     if (mounted) {
-      await ref
+      ref
           .read(asyncStateCounterNotifierProvider.notifier)
-          .incrementCounter();
+          .syncIncrementCounter();
     }
 
     if (!mounted) {
       // expect_lint: use_widget_ref_synchronously
-      await ref
+      ref
           .read(asyncStateCounterNotifierProvider.notifier)
-          .incrementCounter();
+          .syncIncrementCounter();
       return;
     }
 
@@ -137,9 +135,7 @@ class _StatefulUseWidgetRefSynchronouslyLintRuleState
       return;
     }
 
-    await ref
-        .read(asyncStateCounterNotifierProvider.notifier)
-        .incrementCounter();
+    ref.read(asyncStateCounterNotifierProvider.notifier).syncIncrementCounter();
   }
 
   @override
@@ -170,19 +166,19 @@ class _StatefulUseWidgetRefSynchronouslyLintRuleState
             // expect_lint: use_widget_ref_synchronously
             await ref
                 .read(asyncStateCounterNotifierProvider.notifier)
-                .incrementCounter();
+                .asyncIncrementCounter();
 
             if (mounted) {
-              await ref
+              ref
                   .read(asyncStateCounterNotifierProvider.notifier)
-                  .incrementCounter();
+                  .syncIncrementCounter();
             }
 
             if (!mounted) {
               // expect_lint: use_widget_ref_synchronously
-              await ref
+              ref
                   .read(asyncStateCounterNotifierProvider.notifier)
-                  .incrementCounter();
+                  .syncIncrementCounter();
               return;
             }
 
@@ -190,9 +186,9 @@ class _StatefulUseWidgetRefSynchronouslyLintRuleState
               return;
             }
 
-            await ref
+            ref
                 .read(asyncStateCounterNotifierProvider.notifier)
-                .incrementCounter();
+                .syncIncrementCounter();
           },
         ),
       ],
@@ -207,8 +203,12 @@ class AsyncStateCounterNotifier extends _$AsyncStateCounterNotifier {
     return 0;
   }
 
-  Future<void> incrementCounter() {
+  Future<void> asyncIncrementCounter() {
     return Future.delayed(const Duration(seconds: 2), () => state++);
+  }
+
+  void syncIncrementCounter() {
+    state++;
   }
 
   Future<int> getCounter() {

--- a/example/lib/use_widget_ref_synchronously_lint_rule.dart
+++ b/example/lib/use_widget_ref_synchronously_lint_rule.dart
@@ -98,6 +98,108 @@ class UseWidgetRefSynchronouslyLintRule extends HookConsumerWidget {
   }
 }
 
+class StatefulUseWidgetRefSynchronouslyLintRule
+    extends StatefulHookConsumerWidget {
+  const StatefulUseWidgetRefSynchronouslyLintRule({super.key});
+
+  @override
+  ConsumerState<ConsumerStatefulWidget> createState() {
+    return _StatefulUseWidgetRefSynchronouslyLintRuleState();
+  }
+}
+
+class _StatefulUseWidgetRefSynchronouslyLintRuleState
+    extends ConsumerState<StatefulUseWidgetRefSynchronouslyLintRule> {
+  Future<void> incrementCounterWrapper(
+    BuildContext context,
+    WidgetRef ref,
+  ) async {
+    // expect_lint: use_widget_ref_synchronously
+    await ref
+        .read(asyncStateCounterNotifierProvider.notifier)
+        .incrementCounter();
+
+    if (mounted) {
+      await ref
+          .read(asyncStateCounterNotifierProvider.notifier)
+          .incrementCounter();
+    }
+
+    if (!mounted) {
+      // expect_lint: use_widget_ref_synchronously
+      await ref
+          .read(asyncStateCounterNotifierProvider.notifier)
+          .incrementCounter();
+      return;
+    }
+
+    if (!mounted) {
+      return;
+    }
+
+    await ref
+        .read(asyncStateCounterNotifierProvider.notifier)
+        .incrementCounter();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final counter = ref.watch(asyncStateCounterNotifierProvider);
+
+    useEffect(() {
+      WidgetsBinding.instance.addPostFrameCallback((_) async {
+        // expect_lint: use_widget_ref_synchronously
+        final state = ref.watch(asyncStateCounterNotifierProvider);
+        state.isOdd;
+
+        if (mounted) {
+          final state = ref.watch(asyncStateCounterNotifierProvider);
+          state.isEven;
+        }
+      });
+
+      return;
+    }, []);
+
+    return Column(
+      children: [
+        Text('counter: $counter'),
+        GestureDetector(
+          child: Text('increment'),
+          onTap: () async {
+            // expect_lint: use_widget_ref_synchronously
+            await ref
+                .read(asyncStateCounterNotifierProvider.notifier)
+                .incrementCounter();
+
+            if (mounted) {
+              await ref
+                  .read(asyncStateCounterNotifierProvider.notifier)
+                  .incrementCounter();
+            }
+
+            if (!mounted) {
+              // expect_lint: use_widget_ref_synchronously
+              await ref
+                  .read(asyncStateCounterNotifierProvider.notifier)
+                  .incrementCounter();
+              return;
+            }
+
+            if (!mounted) {
+              return;
+            }
+
+            await ref
+                .read(asyncStateCounterNotifierProvider.notifier)
+                .incrementCounter();
+          },
+        ),
+      ],
+    );
+  }
+}
+
 @riverpod
 class AsyncStateCounterNotifier extends _$AsyncStateCounterNotifier {
   @override

--- a/example/lib/use_widget_ref_synchronously_lint_rule.g.dart
+++ b/example/lib/use_widget_ref_synchronously_lint_rule.g.dart
@@ -7,7 +7,7 @@ part of 'use_widget_ref_synchronously_lint_rule.dart';
 // **************************************************************************
 
 String _$asyncStateCounterNotifierHash() =>
-    r'283a51646ba901244877abc28771c64565761a9c';
+    r'365b25d3156473bad6173c6425546d4b46c395ca';
 
 /// See also [AsyncStateCounterNotifier].
 @ProviderFor(AsyncStateCounterNotifier)

--- a/lib/src/rules/use_widget_ref_synchronously/use_widget_ref_synchronous_util.dart
+++ b/lib/src/rules/use_widget_ref_synchronously/use_widget_ref_synchronous_util.dart
@@ -8,6 +8,14 @@ bool isContextMounted(Expression expr) {
   return false;
 }
 
+bool isMountedCondition(Expression expression) {
+  if (expression is SimpleIdentifier) {
+    return expression.name == 'mounted';
+  }
+
+  return false;
+}
+
 bool isAfterEarlyReturn(MethodInvocation node, List<IfStatement> earlyReturns) {
   return earlyReturns.any((earlyReturn) => node.offset > earlyReturn.offset);
 }

--- a/lib/src/rules/use_widget_ref_synchronously/use_widget_ref_synchronous_util.dart
+++ b/lib/src/rules/use_widget_ref_synchronously/use_widget_ref_synchronous_util.dart
@@ -1,6 +1,6 @@
 import 'package:analyzer/dart/ast/ast.dart';
 
-bool isContextMounted(Expression expr) {
+bool isContextMountedCondition(Expression expr) {
   if (expr is PrefixedIdentifier) {
     return expr.prefix.name == 'context' && expr.identifier.name == 'mounted';
   }

--- a/lib/src/rules/use_widget_ref_synchronously/use_widget_ref_synchronously_visitor.dart
+++ b/lib/src/rules/use_widget_ref_synchronously/use_widget_ref_synchronously_visitor.dart
@@ -19,17 +19,19 @@ class UseWidgetRefSynchronouslyVisitor extends RecursiveAstVisitor<void> {
 
   @override
   void visitIfStatement(IfStatement node) {
+    final classDecl = node.thisOrAncestorOfType<ClassDeclaration>();
+    final superclass = classDecl?.extendsClause?.superclass.name2.toString();
     final condition = node.expression;
+    final conditionFunc =
+        superclass == 'ConsumerState' ? isMountedCondition : isContextMounted;
 
-    if (condition is PrefixExpression &&
-        condition.operator.lexeme == '!' &&
-        condition.operand is PrefixedIdentifier) {
+    if (condition is PrefixExpression && condition.operator.lexeme == '!') {
       final operand = condition.operand;
-      wrappedWithNotMounted = isContextMounted(operand);
+      wrappedWithNotMounted = conditionFunc(operand);
       hasEarlyReturn = isEarlyReturn(node.thenStatement);
       node.thenStatement.visitChildren(this);
       wrappedWithNotMounted = false;
-    } else if (isContextMounted(condition)) {
+    } else if (conditionFunc(condition)) {
       wrappedWithMounted = true;
       node.thenStatement.visitChildren(this);
       wrappedWithMounted = false;

--- a/lib/src/rules/use_widget_ref_synchronously/use_widget_ref_synchronously_visitor.dart
+++ b/lib/src/rules/use_widget_ref_synchronously/use_widget_ref_synchronously_visitor.dart
@@ -23,7 +23,9 @@ class UseWidgetRefSynchronouslyVisitor extends RecursiveAstVisitor<void> {
     final superclass = classDecl?.extendsClause?.superclass.name2.toString();
     final condition = node.expression;
     final conditionFunc =
-        superclass == 'ConsumerState' ? isMountedCondition : isContextMounted;
+        superclass == 'ConsumerState'
+            ? isMountedCondition
+            : isContextMountedCondition;
 
     if (condition is PrefixExpression && condition.operator.lexeme == '!') {
       final operand = condition.operand;


### PR DESCRIPTION
# Description
Extend the \`use_widget_ref_synchronously\` rule to recognize \`mounted\` (without \`context.\` prefix) as a valid guard condition for \`ConsumerState\` subclasses, in addition to the existing \`context.mounted\` check.

# What was done
- Added \`isMountedCondition\` to \`use_widget_ref_synchronous_util.dart\` to detect bare \`mounted\` guards used in \`ConsumerState\`
- Renamed \`isContextMounted\` → \`isContextMountedCondition\` for clarity
- Updated \`UseWidgetRefSynchronouslyVisitor.visitIfStatement\` to select the appropriate condition function based on the enclosing class's superclass (\`ConsumerState\` → \`isMountedCondition\`, others → \`isContextMountedCondition\`)
- Updated example file to use \`asyncIncrementCounter\` / \`syncIncrementCounter\` to clearly distinguish async and sync call sites

# What was NOT done
- Did not change the rule's core detection logic for async gaps
- Did not add support for other widget base classes beyond \`ConsumerState\`

# Operation Confirmation

## Prerequisites & Steps
\`\`\`bash
cd example && dart run custom_lint
\`\`\`

# Notes & Related URLs
N/A