### PR TITLE
dev: Pin third-party GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
@@ -27,17 +27,17 @@ jobs:
         run: |
           mkdir -p $HOME/.ssh/
 
-      - uses: kuhnroyal/flutter-fvm-config-action@v2
+      - uses: kuhnroyal/flutter-fvm-config-action@c378498f1d1962d33039c3989411093ef8a17b2c # v3.3
         id: fvm-config-action
 
-      - uses: subosito/flutter-action@v2.18.0
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
         with:
           channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
           flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_VERSION }}
           cache: true
 
       - name: restore pubspec dependencies cache
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: pubspec_cache_id
         with:
           path: |
@@ -58,21 +58,21 @@ jobs:
     needs: setup
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
-      - uses: kuhnroyal/flutter-fvm-config-action@v3
+      - uses: kuhnroyal/flutter-fvm-config-action@c378498f1d1962d33039c3989411093ef8a17b2c # v3.3
         id: fvm-config-action
 
-      - uses: subosito/flutter-action@v2.18.0
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
         with:
           channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
           flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_VERSION }}
           cache: true
 
       - name: restore pubspec dependencies cache
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: pubspec_cache_id
         with:
           path: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,21 +15,21 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
-      - uses: offich/flutter-fvm-dart-sdk-action@v1
+      - uses: offich/flutter-fvm-dart-sdk-action@8d5d0226e69fa1f55eb68662f10525b5c5473eff # v1
         id: flutter-fvm-dart-sdk-version
 
-      - uses: dart-lang/setup-dart@v1
+      - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
         with:
           sdk: ${{ steps.flutter-fvm-dart-sdk-version.outputs.dart-version }}
 
-      - uses: kuhnroyal/flutter-fvm-config-action@v3
+      - uses: kuhnroyal/flutter-fvm-config-action@c378498f1d1962d33039c3989411093ef8a17b2c # v3.3
         id: fvm-config-action
 
-      - uses: subosito/flutter-action@v2.18.0
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
         with:
           channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
           flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_VERSION }}


### PR DESCRIPTION
# Description
Updated third-party GitHub Actions used in `.github/workflows` to the latest versions and changed version specifications to commit hash pinning.

# What was done
- Changed all action version specifications to commit hash format (security hardening)
- `actions/checkout`: v4 → v6.0.2
- `actions/cache`: v4 → v5.0.5
- `kuhnroyal/flutter-fvm-config-action`: v2/v3 → v3.3 (also fixed the setup job in `code-analysis.yml` that was still on v2)
- `subosito/flutter-action`: v2.18.0 → v2.23.0
- `dart-lang/setup-dart`: v1 → v1.7.2
- `offich/flutter-fvm-dart-sdk-action`: v1 (pinned to commit hash)

# What was NOT done
- No changes to workflow logic

# Operation Confirmation

## Prerequisites & Steps
Verify that CI passes.

# Notes & Related URLs

| Action | Old Version | New Version | Changelog |
|---|---|---|---|
| actions/checkout | v4 | v6.0.2 | https://github.com/actions/checkout/releases |
| actions/cache | v4 | v5.0.5 | https://github.com/actions/cache/releases |
| kuhnroyal/flutter-fvm-config-action | v2/v3 | v3.3 | https://github.com/kuhnroyal/flutter-fvm-config-action/releases |
| subosito/flutter-action | v2.18.0 | v2.23.0 | https://github.com/subosito/flutter-action/releases |
| dart-lang/setup-dart | v1 | v1.7.2 | https://github.com/dart-lang/setup-dart/releases |
| offich/flutter-fvm-dart-sdk-action | v1 | v1 | https://github.com/offich/flutter-fvm-dart-sdk-action/releases |