### PR TITLE
Add release job to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,8 +2,8 @@ name: Publish
 
 on:
   push:
-    tags:
-      - "v*"
+    branches:
+      - release
 
 jobs:
   publish:
@@ -39,3 +39,50 @@ jobs:
 
       - name: Publish
         run: dart pub publish --force
+
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Extract version from pubspec.yaml
+        id: version
+        run: |
+          VERSION=$(grep '^version:' pubspec.yaml | awk '{print $2}')
+          VERSION_NAME=$(echo $VERSION | cut -d'+' -f1)
+          TAG_NAME="v${VERSION}"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "version_name=$VERSION_NAME" >> $GITHUB_OUTPUT
+          echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
+          echo "Version: $VERSION (Tag: $TAG_NAME)"
+
+      - name: Create and push tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a ${{ steps.version.outputs.tag_name }} -m "Release ${{ steps.version.outputs.version }}"
+          git push origin ${{ steps.version.outputs.tag_name }}
+
+      - name: Extract release notes from CHANGELOG
+        id: release_notes
+        uses: octivi/release-notes-from-changelog@7e6de14efd823919839acf82f08041f885c8fca9 # v1.0.0
+        with:
+          tag: ${{ steps.version.outputs.tag_name }}
+          changelog: CHANGELOG.md
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
+        with:
+          tag_name: ${{ steps.version.outputs.tag_name }}
+          name: Release ${{ steps.version.outputs.version }}
+          body_path: ${{ steps.release_notes.outputs.release_notes }}
+          draft: false
+          prerelease: false


### PR DESCRIPTION
# Description
Update the publish workflow to trigger on push to the `release` branch and add a `release` job that creates a git tag and GitHub Release automatically.

# What was done
- Changed the workflow trigger from `v*` tag push to `release` branch push
- Added `release` job that:
  - Extracts the version from `pubspec.yaml`
  - Creates and pushes a git tag (`v<version>`)
  - Extracts release notes from `CHANGELOG.md`
  - Creates a GitHub Release

# What was NOT done
- Did not change the `publish` job logic itself

# Operation Confirmation

## Prerequisites & Steps
1. Push to `release` branch
2. Both `publish` and `release` jobs run automatically

# Notes & Related URLs
N/A