### PR TITLE
Add cider and reformat CHANGELOG to Keep a Changelog style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+  - dev: Flutter 3.38.10
+
 ## [0.3.0] - 2025-05-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,37 +1,62 @@
 # Changelog
 
-## 0.3.0
+## [0.3.0] - 2025-05-16
 
-  * Add the following lint:
-    * `use_widget_ref_synchronously`
+### Added
 
-## 0.2.0
+  - Add the following lint:
+    - `use_widget_ref_synchronously`
 
-  * Added the following lint:
-    * `no_disabled_tests`
+## [0.2.0] - 2025-04-17
 
-## 0.1.0
+### Added
 
-  * Added the following lint:
-    * `avoid_empty_container`
+  - Added the following lint:
+    - `no_disabled_tests`
 
-## 0.0.3
+## [0.1.0] - 2025-04-15
 
-  * Publish with example directory included.
+### Added
 
-## 0.0.2
+  - Added the following lint:
+    - `avoid_empty_container`
 
-  * Improve score on pub.dev
-  * Fix automatic deployment by GitHub Actions
+## [0.0.3] - 2025-03-10
 
-## 0.0.1
+### Fixed
 
-  * Modify README.md
+  - Publish with example directory included.
 
-## 0.0.1-dev.2
+## [0.0.2] - 2025-03-10
 
-  * Downgraded required dart sdk version to 3.6.2.
+### Fixed
 
-## 0.0.1-dev.1
+  - Improve score on pub.dev
+  - Fix automatic deployment by GitHub Actions
 
-  * Initial release. This package is under construction.
+## [0.0.1] - 2025-03-09
+
+### Changed
+
+  - Modify README.md
+
+## [0.0.1-dev.2] - 2025-03-09
+
+### Changed
+
+  - Downgraded required dart sdk version to 3.6.2.
+
+## [0.0.1-dev.1] - 2025-03-09
+
+### Added
+
+  - Initial release. This package is under construction.
+
+[0.3.0]: https://github.com/offich/sangria/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/offich/sangria/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/offich/sangria/compare/v0.0.3...v0.1.0
+[0.0.3]: https://github.com/offich/sangria/compare/v0.0.2...v0.0.3
+[0.0.2]: https://github.com/offich/sangria/compare/v0.0.1...v0.0.2
+[0.0.1]: https://github.com/offich/sangria/compare/v0.0.1-dev.2...v0.0.1
+[0.0.1-dev.2]: https://github.com/offich/sangria/compare/v0.0.1-dev.1...v0.0.1-dev.2
+[0.0.1-dev.1]: https://github.com/offich/sangria/releases/tag/v0.0.1-dev.1

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -49,6 +49,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
+  change:
+    dependency: transitive
+    description:
+      name: change
+      sha256: "3bda1ce98526b21927cdea05688563c7065fd7e66d1abbe176c354fef3b2057b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.5"
   characters:
     dependency: transitive
     description:
@@ -73,6 +81,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.1.0"
+  cider:
+    dependency: "direct dev"
+    description:
+      name: cider
+      sha256: "27b9cd9526c70d6cd47299cd644cddaac8102e5f9783ef4bb440840743271883"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.10"
   cli_config:
     dependency: transitive
     description:
@@ -283,6 +299,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  intl:
+    dependency: transitive
+    description:
+      name: intl
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.20.2"
   io:
     dependency: transitive
     description:
@@ -355,6 +379,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.3.1"
+  marker:
+    dependency: transitive
+    description:
+      name: marker
+      sha256: "3dadd01f3b0ffae148ffb3b1bc04290a98e54a465cddbab59727bd2a9fe57750"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.0"
   matcher:
     dependency: transitive
     description:
@@ -451,6 +483,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.2"
+  rfc_6901:
+    dependency: transitive
+    description:
+      name: rfc_6901
+      sha256: "6a43b1858dca2febaf93e15639aa6b0c49ccdfd7647775f15a499f872b018154"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1"
   rxdart:
     dependency: transitive
     description:
@@ -616,6 +656,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  version_manipulation:
+    dependency: transitive
+    description:
+      name: version_manipulation
+      sha256: e90782d610bde19765d2808ec06bc8ed9e04640a4dd07d1a3d370728ce9dae7f
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   vm_service:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,3 +25,4 @@ dev_dependencies:
     sdk: flutter
   flutter_lints: 6.0.0
   pana: 0.23.11
+  cider: 0.2.10


### PR DESCRIPTION
# Description
Add `cider` as a dev dependency for changelog management and reformat `CHANGELOG.md` to follow the [Keep a Changelog](https://keepachangelog.com) format with versioned headers, dated entries, categorized sections, and link references.

# What was done
- Added `cider: 0.2.10` to `dev_dependencies` in `pubspec.yaml`
- Reformatted `CHANGELOG.md` to Keep a Changelog style:
  - Version headers changed to `## [x.y.z] - YYYY-MM-DD` format
  - Added `### Added` / `### Fixed` / `### Changed` sections per version
  - Added `## Unreleased` section at the top
  - Added version comparison link references at the bottom

# What was NOT done
- Did not change the content of changelog entries, only formatting

# Operation Confirmation

## Prerequisites & Steps
1. Run `flutter pub get` to install `cider`
2. Use `dart run cider` to manage changelog entries going forward

# Notes & Related URLs
N/A