### PR TITLE
Add dev/tooling files to .pubignore

### DIFF
--- a/.pubignore
+++ b/.pubignore
@@ -7,6 +7,11 @@
 analysis_options.yaml
 renovate.json
 sangria.iml
+CLAUDE.md
+mise.toml
+package.json
+pnpm-lock.yaml
 
 example/example.iml
+docs/
 test/


### PR DESCRIPTION
# Description
Add development and tooling files to `.pubignore` to prevent them from being included in the published package on pub.dev.

# What was done
- Added the following to `.pubignore`:
  - `CLAUDE.md` — Claude Code instructions file
  - `mise.toml` — mise version manager config
  - `package.json` / `pnpm-lock.yaml` — Node.js tooling files
  - `docs/` — developer documentation directory

# What was NOT done
- Did not change any source code or existing ignore entries

# Operation Confirmation

## Prerequisites & Steps
1. Run `dart pub publish --dry-run` to verify the published file list

# Notes & Related URLs
N/A